### PR TITLE
New xcube rule "data-var-colors"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 - Version 0.0.3 (in development)
   - enhanced "simple" output format by colors and links 
   - new xcube rule "increasing-time"
+  - new xcube rule "data-var-colors"
 
 - Version 0.0.2 (06.01.2025) 
   - more rules

--- a/docs/rule-ref.md
+++ b/docs/rule-ref.md
@@ -46,11 +46,24 @@ Order of dimensions in spatio-temporal datacube variables should be [time, ..., 
 
 Contained in:  `all`-:material-lightning-bolt: `recommended`-:material-lightning-bolt:
 
+### :material-lightbulb: `data-var-colors`
+
+Spatial data variables should encode xcube color mappings in their metadata.
+[More information.](https://xcube.readthedocs.io/en/latest/cubespec.html#encoding-of-colors)
+
+Contained in:  `all`-:material-lightning-bolt: `recommended`-:material-alert:
+
 ### :material-lightbulb: `grid-mapping-naming`
 
 Grid mapping variables should be called 'spatial_ref' or 'crs' for compatibility with rioxarray and other packages.
 
 Contained in:  `all`-:material-lightning-bolt: `recommended`-:material-alert:
+
+### :material-bug: `increasing-time`
+
+Time coordinate labels should be monotonically increasing.
+
+Contained in:  `all`-:material-lightning-bolt: `recommended`-:material-lightning-bolt:
 
 ### :material-bug: `lat-lon-naming`
 

--- a/tests/plugins/xcube/rules/test_data_var_colors.py
+++ b/tests/plugins/xcube/rules/test_data_var_colors.py
@@ -44,14 +44,30 @@ def make_dataset():
 valid_dataset_1 = make_dataset()
 
 invalid_dataset_1 = make_dataset()
-invalid_dataset_1.chl.attrs = {"units": "mg/m^-3"}
+invalid_dataset_1.chl.attrs = {
+    "units": "mg/m^-3",
+    # Missing:
+    # "color_bar_name": "plasma",
+    # "color_value_min": 0,
+    # "color_value_max": 100,
+    # "color_norm": "log",
+}
 invalid_dataset_2 = make_dataset()
 invalid_dataset_2.chl.attrs = {
     "units": "mg/m^-3",
     "color_bar_name": "plasma",
+    # Missing:
+    # "color_value_min": 0,
+    # "color_value_max": 100,
+    # "color_norm": "log",
+}
+invalid_dataset_3 = make_dataset()
+invalid_dataset_3.chl.attrs = {
+    "units": "mg/m^-3",
+    "color_bar_name": "plasma",
     "color_value_min": 0,
     "color_value_max": 100,
-    "color_norm": "exp",
+    "color_norm": "ln",  # wrong
 }
 
 LatLonNamingTest = RuleTester.define_test(
@@ -62,5 +78,7 @@ LatLonNamingTest = RuleTester.define_test(
     ],
     invalid=[
         RuleTest(dataset=invalid_dataset_1),
+        RuleTest(dataset=invalid_dataset_2),
+        RuleTest(dataset=invalid_dataset_3),
     ],
 )

--- a/tests/plugins/xcube/rules/test_data_var_colors.py
+++ b/tests/plugins/xcube/rules/test_data_var_colors.py
@@ -1,0 +1,66 @@
+import numpy as np
+
+from xrlint.plugins.xcube.rules.data_var_colors import DataVarColors
+
+import xarray as xr
+
+from xrlint.testing import RuleTester, RuleTest
+
+
+def make_dataset():
+    dims = ["time", "y", "x"]
+    n = 5
+    return xr.Dataset(
+        attrs=dict(title="v-data"),
+        coords={
+            dims[2]: xr.DataArray(
+                np.linspace(0, 1, n), dims=dims[2], attrs={"units": "m"}
+            ),
+            dims[1]: xr.DataArray(
+                np.linspace(0, 1, n), dims=dims[1], attrs={"units": "m"}
+            ),
+            dims[0]: xr.DataArray(
+                [2010, 2011, 2012, 2013, 2014],
+                dims=dims[0],
+                attrs={"units": "years"},
+            ),
+        },
+        data_vars={
+            "chl": xr.DataArray(
+                np.random.random((n, n, n)),
+                dims=dims,
+                attrs={
+                    "units": "mg/m^-3",
+                    "color_bar_name": "plasma",
+                    "color_value_min": 0,
+                    "color_value_max": 100,
+                    "color_norm": "log",
+                },
+            ),
+        },
+    )
+
+
+valid_dataset_1 = make_dataset()
+
+invalid_dataset_1 = make_dataset()
+invalid_dataset_1.chl.attrs = {"units": "mg/m^-3"}
+invalid_dataset_2 = make_dataset()
+invalid_dataset_2.chl.attrs = {
+    "units": "mg/m^-3",
+    "color_bar_name": "plasma",
+    "color_value_min": 0,
+    "color_value_max": 100,
+    "color_norm": "exp",
+}
+
+LatLonNamingTest = RuleTester.define_test(
+    "data-var-colors",
+    DataVarColors,
+    valid=[
+        RuleTest(dataset=valid_dataset_1),
+    ],
+    invalid=[
+        RuleTest(dataset=invalid_dataset_1),
+    ],
+)

--- a/tests/plugins/xcube/test_plugin.py
+++ b/tests/plugins/xcube/test_plugin.py
@@ -21,6 +21,7 @@ class ExportPluginTest(TestCase):
             {
                 "any-spatial-data-var",
                 "cube-dims-order",
+                "data-var-colors",
                 "grid-mapping-naming",
                 "lat-lon-naming",
                 "single-grid-mapping",

--- a/xrlint/plugins/xcube/__init__.py
+++ b/xrlint/plugins/xcube/__init__.py
@@ -17,6 +17,7 @@ def export_plugin() -> Plugin:
             "rules": {
                 "xcube/any-spatial-data-var": "error",
                 "xcube/cube-dims-order": "error",
+                "xcube/data-var-colors": "warn",
                 "xcube/grid-mapping-naming": "warn",
                 "xcube/increasing-time": "error",
                 "xcube/lat-lon-naming": "error",

--- a/xrlint/plugins/xcube/rules/data_var_colors.py
+++ b/xrlint/plugins/xcube/rules/data_var_colors.py
@@ -1,0 +1,43 @@
+import numpy as np
+
+from xrlint.node import DataArrayNode
+from xrlint.plugins.xcube.rules import plugin
+from xrlint.plugins.xcube.util import is_spatial_var
+from xrlint.rule import RuleContext
+from xrlint.rule import RuleOp
+
+
+@plugin.define_rule(
+    "data-var-colors",
+    version="1.0.0",
+    type="suggestion",
+    description=(
+        "Spatial data variables should encode"
+        " xcube color mappings in their metadata."
+    ),
+    docs_url=(
+        "https://xcube.readthedocs.io/en/latest/cubespec.html#encoding-of-colors"
+    ),
+)
+class DataVarColors(RuleOp):
+    def data_array(self, ctx: RuleContext, node: DataArrayNode):
+        array = node.data_array
+        if not node.in_data_vars() or not is_spatial_var(array):
+            return
+        attrs = array.attrs
+        color_bar_name = attrs.get("color_bar_name")
+        if not color_bar_name:
+            ctx.report("Missing attribute 'color_bar_name'")
+        else:
+            color_value_min = attrs.get("color_value_min")
+            color_value_max = attrs.get("color_value_max")
+            if color_value_min is None or color_value_max is None:
+                ctx.report(
+                    "Missing both or one of 'color_value_min' and 'color_value_max'"
+                )
+
+            color_norm = attrs.get("color_norm")
+            if color_norm and color_norm not in ("lin", "log"):
+                ctx.report(
+                    "Invalid value of attribute 'color_norm', should be 'lin' or 'log'"
+                )


### PR DESCRIPTION
Added a new rule.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [ ] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
