### PR TITLE
Fix scanning URLs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # XRLint Change History
 
+## Version 0.4.1 (in development)
+
+- Fixed an issue that prevented recursively traversing folders referred 
+  to by URLs (such as `s3://<bucket>/<path>/`) rather than local directory 
+  paths. (#39)
+
 ## Version 0.4.0 (from 2025-01-27)
 
 - Fixed and enhanced core rule `time-coordinate`. `(#33)

--- a/xrlint/cli/engine.py
+++ b/xrlint/cli/engine.py
@@ -175,6 +175,7 @@ class XRLint(FormatterContext):
         for file_path in file_paths:
             _fs, root = fsspec.url_to_fs(file_path)
             fs: fsspec.AbstractFileSystem = _fs
+            is_local = isinstance(fs, fsspec.implementations.local.LocalFileSystem)
 
             config = compute_config(file_path)
             if config is not None:
@@ -185,6 +186,7 @@ class XRLint(FormatterContext):
                 for path, dirs, files in fs.walk(root, topdown=True):
                     for d in list(dirs):
                         d_path = f"{path}/{d}"
+                        d_path = d_path if is_local else fs.unstrip_protocol(d_path)
                         c = compute_config(d_path)
                         if c is not None:
                             dirs.remove(d)
@@ -192,6 +194,7 @@ class XRLint(FormatterContext):
 
                     for f in files:
                         f_path = f"{path}/{f}"
+                        f_path = f_path if is_local else fs.unstrip_protocol(f_path)
                         c = compute_config(f_path)
                         if c is not None:
                             yield f_path, c

--- a/xrlint/version.py
+++ b/xrlint/version.py
@@ -1,1 +1,1 @@
-version = "0.4.0"
+version = "0.4.1.dev0"


### PR DESCRIPTION
Fixed an issue that prevented recursively traversing folders referred to by URLs (such as `s3://<bucket>/<path>/`) rather than local directory paths. 

Closes #39

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [x] Added docstrings and API docs for any new/modified user-facing classes and functions
* [x] Changes/features documented in `docs/*`
* [x] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
