### PR TITLE
Add ms, µs and ns to time coordinates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # XRLint Change History
 
+## Version 0.5.2 (in development)
+
+### Adjustments and Enhancements
+
+- Core rule 'time-coordinates' now support ms, µs and ns. (#66)
+
 ## Version 0.5.1 (from 2025-02-21)
 
 - XRLint now also loads default configuration from files named 

--- a/xrlint/plugins/core/rules/time_coordinate.py
+++ b/xrlint/plugins/core/rules/time_coordinate.py
@@ -55,7 +55,7 @@ _RE_TZ = re.compile(r"^[+-]\d{1,2}:\d{1,2}$")
 
 @plugin.define_rule(
     "time-coordinate",
-    version="1.0.0",
+    version="1.0.1",
     type="problem",
     description=(
         "Time coordinates should have valid and unambiguous time units encoding."

--- a/xrlint/plugins/core/rules/time_coordinate.py
+++ b/xrlint/plugins/core/rules/time_coordinate.py
@@ -35,12 +35,21 @@ _UNAMBIGUOUS_UNITS_OF_TIME = (
     "second",
     "sec",
     "s",
+    "milliseconds",
+    "millisecond",
+    "ms",
+    "microseconds",
+    "microsecond",
+    "µs",
+    "nanoseconds",
+    "nanosecond",
+    "ns",
 )
 
 _ALL_UNITS_OF_TIME = (*_AMBIGUOUS_UNITS_OF_TIME, *_UNAMBIGUOUS_UNITS_OF_TIME)
 
 _RE_DATE = re.compile(r"^\d{4}-\d{1,2}-\d{1,2}$")
-_RE_TIME = re.compile(r"^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,6})?$")
+_RE_TIME = re.compile(r"^\d{1,2}:\d{1,2}:\d{1,2}(\.\d{1,9})?$")
 _RE_TZ = re.compile(r"^[+-]\d{1,2}:\d{1,2}$")
 
 

--- a/xrlint/version.py
+++ b/xrlint/version.py
@@ -2,4 +2,4 @@
 #  This software is distributed under the terms and conditions of the
 #  MIT license (https://mit-license.org/).
 
-version = "0.5.1"
+version = "0.5.2.dev0"


### PR DESCRIPTION
This PR adds ms, µs and ns as allowed units of time coordinates.

Closes #66.

Checklist (strike out non-applicable):

* [x] Changes documented in `CHANGES.md`
* [x] Related issue exists and is referred to in the PR description and `CHANGES.md`
* [ ] Added docstrings and API docs for any new/modified user-facing classes and functions
* [ ] Changes/features documented in `docs/*`
* [ ] Unit-tests adapted/added for changes/features 
* [x] Test coverage remains or increases (target 100%)
